### PR TITLE
changes to allow maketarget work with makeclothes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ This repository contains a reimplementation of MakeTarget.
 This version of the addon is blender 2.80 only. If you still use blender 2.79, you're better off using the previous 
 version of MakeTarget. You can find the latest working version of the previous codebase in the "v1" branch in this repository.
 
-Further, this version of the addon depends heavily on [the makehuman plugin for blender](https://github.com/makehumancommunity/makehuman-plugin-for-blender).
-In practise, you will need this in order to load a human mesh.  
+Further, this version of the addon depends heavily on [the makehuman plugin for blender](https://github.com/makehumancommunity/makehuman-plugin-for-blender) or
+[makeclothes plugin for blender](https://github.com/makehumancommunity/community-plugins-makeclothes).
+
+In practise, you will need this in order to load a human mesh. The scale of the mesh is predefined by the makehuman plugin for blender - or - set to 1.0 when the mesh is loaded with makeclothes plugin.
+
+The data is written as vertex-number, followed by x, y, z values. These values are rounded and have the same form as all the lines in uncompiled MakeHuman targets.
 
 ## Usage
 

--- a/maketarget/__init__.py
+++ b/maketarget/__init__.py
@@ -47,6 +47,8 @@ __all__ = [
 ]
 
 def register():
+    if not hasattr(bpy.types.Object, "MhPrimaryTargetName"):
+        bpy.types.Object.MhPrimaryTargetName  = StringProperty(name="Target name", description="name will be used as a default for primary target and file name", default="primary_target")
 
     for cls in MAKETARGET2_CLASSES:
         register_class(cls)

--- a/maketarget/createprimarytarget.py
+++ b/maketarget/createprimarytarget.py
@@ -24,12 +24,13 @@ class MHC_OT_CreatePrimaryTargetOperator(bpy.types.Operator):
 
         obj = context.active_object
         basis = obj.shape_key_add(name="Basis",from_mix=False)
-        primaryTarget = obj.shape_key_add(name="PrimaryTarget", from_mix=True)
+        primtarget = obj.MhPrimaryTargetName
+        primaryTarget = obj.shape_key_add(name=primtarget, from_mix=True)
         primaryTarget.value = 1.0
 
-        idx = context.active_object.data.shape_keys.key_blocks.find('PrimaryTarget')
+        idx = context.active_object.data.shape_keys.key_blocks.find(primtarget)
         context.active_object.active_shape_key_index = idx
 
-        self.report({'INFO'},"Target initialized")
+        self.report({'INFO'},"Target " + primtarget + " initialized")
 
         return {'FINISHED'}

--- a/maketarget/loadprimarytarget.py
+++ b/maketarget/loadprimarytarget.py
@@ -28,14 +28,15 @@ class MHC_OT_LoadPrimaryTargetOperator(bpy.types.Operator, ImportHelper):
         sks = obj.data.shape_keys
         pt = sks.key_blocks["PrimaryTarget"]
 
-        scaleFactor = 0.1
-        scaleMode = str(bpy.context.scene.MhScaleMode)
+        scaleFactor = 1.0
+        if hasattr(bpy.context.scene, "MhScaleMode"):
+            scaleMode = str(bpy.context.scene.MhScaleMode)
 
-        if scaleMode == "DECIMETER":
-            scaleFactor = 1.0
+            if scaleMode == "METER":
+                scaleFactor = 0.1
 
-        if scaleMode == "CENTIMETER":
-            scaleFactor = 10.0
+            if scaleMode == "CENTIMETER":
+                scaleFactor = 10.0
 
         with open(self.filepath,'r') as f:
             for line in f:

--- a/maketarget/loadprimarytarget.py
+++ b/maketarget/loadprimarytarget.py
@@ -14,19 +14,20 @@ class MHC_OT_LoadPrimaryTargetOperator(bpy.types.Operator, ImportHelper):
 
     def execute(self, context):
         filename, extension = os.path.splitext(self.filepath)
-        bn = os.path.basename(filename)
-        #context.scene.MhPrimaryTargetName = bn
+        primtarget = os.path.basename(filename)
 
         obj = context.active_object
+        obj.MhPrimaryTargetName = primtarget
+
         basis = obj.shape_key_add(name="Basis", from_mix=False)
-        primaryTarget = obj.shape_key_add(name="PrimaryTarget", from_mix=True)
+        primaryTarget = obj.shape_key_add(name=primtarget, from_mix=True)
         primaryTarget.value = 1.0
 
-        idx = context.active_object.data.shape_keys.key_blocks.find('PrimaryTarget')
+        idx = context.active_object.data.shape_keys.key_blocks.find(primtarget)
         context.active_object.active_shape_key_index = idx
 
         sks = obj.data.shape_keys
-        pt = sks.key_blocks["PrimaryTarget"]
+        pt = sks.key_blocks[primtarget]
 
         scaleFactor = 1.0
         if hasattr(bpy.context.scene, "MhScaleMode"):

--- a/maketarget/maketarget2.py
+++ b/maketarget/maketarget2.py
@@ -17,19 +17,35 @@ class MHC_PT_MakeTarget_Panel(bpy.types.Panel):
 
         createBox = layout.box()
         createBox.label(text="Initialize", icon="MESH_DATA")
-        createBox.operator("mh_community.create_primary_target", text="Create target")
-        createBox.operator("mh_community.load_primary_target", text="Load target")
 
-        saveBox = layout.box()
-        saveBox.label(text="Save Target", icon="MESH_DATA")
-        saveBox.operator("mh_community.save_primary_target", text="Save target")
+        base_available = False
+        for obj in scn.objects:
+            if hasattr(obj, "MhObjectType"):
+                if obj.MhObjectType == "Basemesh":
+                    base_available = True
+                    break
 
-        symmetrizeBox = layout.box()
-        symmetrizeBox.label(text="Symmetrize", icon="MESH_DATA")
-        symmetrizeBox.operator("mh_community.symmetrize_left", text="Copy -x to +x")
-        symmetrizeBox.operator("mh_community.symmetrize_right", text="Copy +x to -x")
+        obj = context.active_object
 
-        debugBox = layout.box()
-        debugBox.label(text="Debug Target", icon="MESH_DATA")
-        debugBox.operator("mh_community.print_primary_target", text="Print target")
+        if not base_available:
+            createBox.label(text="- load a base mesh first -")
+        elif obj is None or obj.type != "MESH":
+            createBox.label(text="- select the base mesh object -")
+        else:
+            createBox.prop(obj, "MhPrimaryTargetName")
+            createBox.operator("mh_community.create_primary_target", text="Create target")
+            createBox.operator("mh_community.load_primary_target", text="Load target")
+
+            saveBox = layout.box()
+            saveBox.label(text="Save Target", icon="MESH_DATA")
+            saveBox.operator("mh_community.save_primary_target", text="Save target")
+
+            symmetrizeBox = layout.box()
+            symmetrizeBox.label(text="Symmetrize", icon="MESH_DATA")
+            symmetrizeBox.operator("mh_community.symmetrize_left", text="Copy -x to +x")
+            symmetrizeBox.operator("mh_community.symmetrize_right", text="Copy +x to -x")
+
+            debugBox = layout.box()
+            debugBox.label(text="Debug Target", icon="MESH_DATA")
+            debugBox.operator("mh_community.print_primary_target", text="Print target")
 

--- a/maketarget/saveprimarytarget.py
+++ b/maketarget/saveprimarytarget.py
@@ -26,14 +26,16 @@ class MHC_OT_SavePrimaryTargetOperator(bpy.types.Operator, ExportHelper):
 
     def execute(self, context):
 
-        scaleFactor = 10.0
-        scaleMode = str(bpy.context.scene.MhScaleMode)
+        scaleFactor = 1.0
 
-        if scaleMode == "DECIMETER":
-            scaleFactor = 1.0
+        if hasattr(bpy.context.scene, "MhScaleMode"):
+            scaleMode = str(bpy.context.scene.MhScaleMode)
 
-        if scaleMode == "CENTIMETER":
-            scaleFactor = 0.1
+            if scaleMode == "METER":
+                scaleFactor = 10.0
+
+            if scaleMode == "CENTIMETER":
+                scaleFactor = 0.1
 
         obj = context.active_object
         sks = obj.data.shape_keys
@@ -51,9 +53,34 @@ class MHC_OT_SavePrimaryTargetOperator(bpy.types.Operator, ExportHelper):
                 ptvco = pt.data[i].co
                 if btvco != ptvco:
                     diffco = ptvco - btvco
-                    x = str(diffco[0] * scaleFactor)
-                    y = str(-diffco[1] * scaleFactor)
-                    z = str(diffco[2] * scaleFactor)
+
+                    # write notation used by makehuman
+                    #
+                    x = str(round (diffco[0] * scaleFactor, 3))
+                    y = str(round (-diffco[1] * scaleFactor, 3))
+                    z = str(round (diffco[2] * scaleFactor, 3))
+
+                    if x == "0.0" or x == "-0.0":
+                        x = "0"
+                    elif x.startswith("-0."):
+                        x = x.replace("-0", "-")
+                    elif x.startswith("0."):
+                        x = x.replace("0.", ".")
+
+                    if y == "0.0" or y == "-0.0":
+                        y = "0"
+                    elif y.startswith("-0."):
+                        y = y.replace("-0", "-")
+                    elif y.startswith("0."):
+                        y = y.replace("0.", ".")
+
+                    if z == "0.0" or z == "-0.0":
+                        z = "0"
+                    elif z.startswith("-0."):
+                        z = z.replace("-0", "-")
+                    elif z.startswith("0."):
+                        z = z.replace("0.", ".")
+
                     f.write(str(i) + " " + x + " " + z + " " + y + "\n")
                 i = i + 1
 


### PR DESCRIPTION
Scale and basemesh are needed from external sources. If a standard
basemesh is loaded, scale should be 1.0. So if the attribute isn't there, 1.0 is assumed.

Furthermore I changed output to the one makehuman uses for the standard
targets. Now it is possible to load an existing
standard target, change it and save it, the difference will only be the
new lines.